### PR TITLE
Set property in trait to public so that it can be loaded

### DIFF
--- a/models/DataObject/Traits/DefaultValueTrait.php
+++ b/models/DataObject/Traits/DefaultValueTrait.php
@@ -28,7 +28,7 @@ use Pimcore\Model\DataObject\Objectbrick\Data\AbstractData;
 trait DefaultValueTrait
 {
     /** @var string */
-    protected $defaultValueGenerator = '';
+    public $defaultValueGenerator = '';
 
     /**
      * @param \Pimcore\Model\DataObject\Concrete $object


### PR DESCRIPTION
The property is currently protected which prevents that the value can be accessed from outside. If a class definition is loaded, the value is empty in the UI.

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `10.x`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #9198

